### PR TITLE
Update EmailableReporter2.java to make the summary hyperlink work

### DIFF
--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -196,7 +196,7 @@ public class EmailableReporter2 implements IReporter {
      * Writes a summary of all the test scenarios.
      */
     protected void writeScenarioSummary() {
-        writer.print("<table>");
+        writer.print("<table id=\"summary\">");
         writer.print("<thead>");
         writer.print("<tr>");
         writer.print("<th>Class</th>");


### PR DESCRIPTION
Fixes # .
Added ```id="summary"``` to summary table to fix ```back to summary``` hyperlink
### Did you remember to?

- [ No] Add test case(s)
- [ No] Update `CHANGES.txt`

